### PR TITLE
refactor: rename parameter access to acl

### DIFF
--- a/_docs/data/data.yaml
+++ b/_docs/data/data.yaml
@@ -48,8 +48,8 @@ properties:
     type: bool
     required: false
 
-  access:
-    description: Access control settings.
+  acl:
+    description: Access control list.
     type: map
     required: false
 

--- a/cmd/drone-s3-sync/config.go
+++ b/cmd/drone-s3-sync/config.go
@@ -78,9 +78,9 @@ func settingsFlags(settings *plugin.Settings, category string) []cli.Flag {
 			Category:    category,
 		},
 		&cli.GenericFlag{
-			Name:     "access",
-			Usage:    "access control settings",
-			EnvVars:  []string{"PLUGIN_ACCESS", "PLUGIN_ACL"},
+			Name:     "acl",
+			Usage:    "access control list",
+			EnvVars:  []string{"PLUGIN_ACL"},
 			Value:    &StringMapFlag{},
 			Category: category,
 		},

--- a/cmd/drone-s3-sync/main.go
+++ b/cmd/drone-s3-sync/main.go
@@ -44,7 +44,7 @@ func run(settings *plugin.Settings) cli.ActionFunc {
 	return func(ctx *cli.Context) error {
 		urfave.LoggingFromContext(ctx)
 
-		settings.Access = ctx.Generic("access").(*StringMapFlag).Get()
+		settings.ACL = ctx.Generic("acl").(*StringMapFlag).Get()
 		settings.CacheControl = ctx.Generic("cache-control").(*StringMapFlag).Get()
 		settings.ContentType = ctx.Generic("content-type").(*StringMapFlag).Get()
 		settings.ContentEncoding = ctx.Generic("content-encoding").(*StringMapFlag).Get()

--- a/plugin/impl.go
+++ b/plugin/impl.go
@@ -19,7 +19,7 @@ type Settings struct {
 	Source                 string
 	Target                 string
 	Delete                 bool
-	Access                 map[string]string
+	ACL                    map[string]string
 	CacheControl           map[string]string
 	ContentType            map[string]string
 	ContentEncoding        map[string]string


### PR DESCRIPTION
BREAKING CHANGE: The parameter `access` was renamed to `acl` and the environment variable `PLUGIN_ACCESS` was removed.